### PR TITLE
♻️ refactor: 파일 이름 수정 메서드 및 회수 Files.walk 추가

### DIFF
--- a/src/main/java/Obsidian/demo/utils/FileSystemUtil.java
+++ b/src/main/java/Obsidian/demo/utils/FileSystemUtil.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -22,53 +23,44 @@ import Obsidian.demo.dto.FileNodeDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class FileSystemUtil {
+
 	private static final String homeDir = System.getProperty("user.home") + "/obsidian";
 	private static final String vaultPath = homeDir + "/note/";
 	private static final String publicPath = homeDir + "/public/";
 
 	private final RedisTemplate<String, Object> redisTemplate;
-	/**
-	 * 이미 배포되어있는 파일인지 확인하는 메서드
-	 * @param relativePath
-	 * @return htmlPath
-	 */
+
 	public static Path findPublishedHtmlFile(String relativePath) {
 		String htmlFilePath = publicPath + relativePath.replaceAll("\\.md$", ".html");
 		Path htmlPath = Paths.get(htmlFilePath);
 		return Files.exists(htmlPath) ? htmlPath : null;
 	}
 
-	/**
-	 * DeleteFolderOrFile 서비스 메서드에서 재귀적으로 폴더나 파일을 삭제를 수행하는 함수
-	 * @param path
-	 * @throws IOException
-	 */
 	public static void deleteRecursively(Path path) throws IOException {
 		if (!Files.exists(path)) {
 			return;
 		}
 
 		if (Files.isDirectory(path)) {
-			Files.walk(path)
-				.sorted(Comparator.reverseOrder()) // 내부 파일 먼저 삭제 후 폴더 삭제
-				.map(Path::toFile)
-				.forEach(File::delete);
+			try (Stream<Path> paths = Files.walk(path)) {
+				paths.sorted(Comparator.reverseOrder())
+						.forEach(p -> {
+							try {
+								Files.delete(p);
+							} catch (IOException e) {
+								log.error("파일 또는 디렉토리 삭제 중 오류 발생: {}", e.getMessage());
+							}
+						});
+			}
 		} else {
 			Files.deleteIfExists(path);
 		}
 	}
 
-	/**
-	 * 파일 혹은 폴더를 FileTree의 하나의 노드로 변환
-	 * @param path
-	 * @return
-	 * @throws IOException
-	 */
 	public static FileNodeDto buildFileNode(Path path) throws IOException {
 		boolean isFolder = Files.isDirectory(path);
 		List<FileNodeDto> children = new ArrayList<>();
@@ -83,11 +75,6 @@ public class FileSystemUtil {
 		return new FileNodeDto(path.getFileName().toString(), isFolder, false, path.toString(), children);
 	}
 
-	/**
-	 * isPublish 값 할당 함수. 파일트리를 구성할때 해당 파일이 /public에 존재하는지 체크하는 함수
-	 * @param files
-	 * @param publicHtmlFiles
-	 */
 	public static void markPublishedFiles(List<FileNodeDto> files, Set<String> publicHtmlFiles) {
 		for (FileNodeDto file : files) {
 			if (!file.isFolder() && file.getName().endsWith(".md")) {
@@ -102,18 +89,13 @@ public class FileSystemUtil {
 		}
 	}
 
-	/**
-	 * 파일 이름에서 확장자를 제거하고 순수한 파일 이름만 반환하는 함수
-	 * @param fileName
-	 * @return
-	 */
 	public static String getFileNameWithoutExtension(String fileName) {
 		int lastDotIndex = fileName.lastIndexOf('.');
 		return (lastDotIndex != -1) ? fileName.substring(0, lastDotIndex) : fileName;
 	}
 
 	@CacheEvict(value = "fileTreeCache", key = "'fileTree'")
-	public  List<FileNodeDto> updateFileTree() {
+	public List<FileNodeDto> updateFileTree() {
 		Path root = Paths.get(vaultPath);
 		Path publicRoot = Paths.get(publicPath);
 		System.out.println("UpdateCache");
@@ -138,12 +120,16 @@ public class FileSystemUtil {
 		}
 
 		Set<String> publicHtmlFiles = new HashSet<>();
+
 		if (Files.exists(publicRoot)) {
-			try (DirectoryStream<Path> publicStream = Files.newDirectoryStream(publicRoot, "*.html")) {
-				for (Path path : publicStream) {
-					String fileNameWithoutExtension = getFileNameWithoutExtension(path.getFileName().toString());
-					publicHtmlFiles.add(fileNameWithoutExtension);
-				}
+			try (Stream<Path> paths = Files.walk(publicRoot)) {
+				paths.filter(Files::isRegularFile)
+						.filter(path -> path.toString().endsWith(".html"))
+						.forEach(path -> {
+							System.out.println("path = " + path);
+							String fileNameWithoutExtension = getFileNameWithoutExtension(path.getFileName().toString());
+							publicHtmlFiles.add(fileNameWithoutExtension);
+						});
 			} catch (IOException e) {
 				log.error("Public 폴더 조회 중 오류 발생: {}", e.getMessage());
 			}
@@ -156,5 +142,4 @@ public class FileSystemUtil {
 
 		return noteFiles;
 	}
-
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #

## 📌 개요
- FileTree가 재귀적으로 하위 폴더를 탐색하지 못하여 회수되지 않는 이슈 발생
- DirectoryStream 대신 FileWalk를 사용하는 방법으로 변경
- 파일 이름 변경 메서드 수정

## 🔁 변경 사항

## 📸 스크린샷 (선택)

## 👀 기타 더 이야기해볼 점 (선택)

## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [X] PR 템플릿에 맞추어 작성했어요.
- [X] 변경 내용에 대한 테스트를 진행했어요.
- [X] 프로그램이 정상적으로 동작해요.
- [X] PR에 적절한 라벨을 선택했어요.
- [X] 불필요한 코드는 삭제했어요.
