### PR TITLE
:bug: Fix: FileTree의 Publish 마킹 오류해결 , Unpublish 실패 파일 리스트 리턴 

### DIFF
--- a/src/main/java/Obsidian/demo/service/FileSystemService.java
+++ b/src/main/java/Obsidian/demo/service/FileSystemService.java
@@ -25,7 +25,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FileSystemService {
 
-	private final String rootPath = System.getProperty("user.home") + "/obsidian";
+	// private final String rootPath = System.getProperty("user.home") + "/obsidian";
+	private final String rootPath =  "/home/obsidian";
 	private final String vaultPath = rootPath + "/note/";
 	private final String publicPath = rootPath + "/public/";
 

--- a/src/main/java/Obsidian/demo/service/ImageUploadService.java
+++ b/src/main/java/Obsidian/demo/service/ImageUploadService.java
@@ -15,7 +15,8 @@ import java.util.UUID;
 
 @Service
 public class ImageUploadService {
-    private final String homeDir = System.getProperty("user.home")+"/obsidian";
+    private final String homeDir = "/home/obsidian";
+    // private final String homeDir = System.getProperty("user.home")+"/obsidian";
     private final String imagePath = homeDir + "/images/";
 
     public List<String> uploadImageFiles(MultipartFile[] multipartFiles) throws IOException {

--- a/src/main/java/Obsidian/demo/service/PublishService.java
+++ b/src/main/java/Obsidian/demo/service/PublishService.java
@@ -34,7 +34,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PublishService {
 
-	private final String homeDir = System.getProperty("user.home") + "/obsidian";
+	// private final String homeDir = System.getProperty("user.home") + "/obsidian";
+	private final String homeDir =  "/home/obsidian";
 	private final String vaultPath = homeDir + "/note/";
 	private final String publicPath = homeDir + "/public/";
 

--- a/src/main/java/Obsidian/demo/utils/FileSystemUtil.java
+++ b/src/main/java/Obsidian/demo/utils/FileSystemUtil.java
@@ -28,7 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class FileSystemUtil {
 
-	private static final String homeDir = System.getProperty("user.home") + "/obsidian";
+	// private static final String homeDir = System.getProperty("user.home") + "/obsidian";
+	private static final String homeDir = "/home/obsidian";
 	private static final String vaultPath = homeDir + "/note/";
 	private static final String publicPath = homeDir + "/public/";
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #28 

## 📌 개요
- Filetree가 동일한 이름의 파일을 하나로 처리하는 이슈 해결

## 🔁 변경 사항
- FileSystemUtil.java의 markPublishedFiles에서 note 폴더와 publish 폴더 비교하는 로직을 파일이름뿐만 아니라 상대경로를 추출하여 비교하도록 변경
## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a6d0862d-572f-4571-8c46-9d395f3d8d3e)
### test/test.md만 배포 
![image](https://github.com/user-attachments/assets/a96be757-083f-47fd-98ad-382ff4b002ed)
### test.md배포 
![image](https://github.com/user-attachments/assets/90a12421-2906-46a5-bae3-189ced018334)
### test.html 회수
![image](https://github.com/user-attachments/assets/1398a1e5-ac94-4bc4-b836-c908ca30537d)
### ✨ 회수 이후, test만 false처리 된 모습
![image](https://github.com/user-attachments/assets/20ceffb7-1c98-40fb-b547-299c40ad7093)

### Unpublish에서 회수에 실패(파일이름 오기, 경로 존재하지않음)한 파일을 return 하게 해줌.
![image](https://github.com/user-attachments/assets/f0efd25a-817b-436a-9605-cb2e8e8beb22)


## 👀 기타 더 이야기해볼 점 (선택)
- 회수 api에서 해당 파일이 존재하지 않아도 오류가 발생하지 않음. -> 해결
## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [X] PR 템플릿에 맞추어 작성했어요.
- [X] 변경 내용에 대한 테스트를 진행했어요.
- [X] 프로그램이 정상적으로 동작해요.
- [X] PR에 적절한 라벨을 선택했어요.
- [X] 불필요한 코드는 삭제했어요.
