### PR TITLE
♻️ [refactor] : saveMarkdown 역할 분리 및 API 수정

### DIFF
--- a/src/main/java/Obsidian/demo/controller/FileSystemController.java
+++ b/src/main/java/Obsidian/demo/controller/FileSystemController.java
@@ -92,14 +92,14 @@ public class FileSystemController {
 		}
 	}
 
-	@Operation(summary = "마크다운 저장", description = "마크다운 파일을 저장합니다.")
-	@PostMapping("/save")
-	public ResponseEntity<ApiResponse<String>> saveMarkdown(@RequestBody MarkDownSaveRequestDTO requestDTO) {
+	@Operation(summary = "마크다운 내용 업데이트", description = "기존 마크다운 파일의 내용을 업데이트합니다.")
+	@PutMapping("/update")
+	public ResponseEntity<ApiResponse<String>> updateMarkdown(@RequestBody MarkDownSaveRequestDTO requestDTO) {
 		try {
-			fileSystemService.saveMarkdown(requestDTO);
-			return ResponseEntity.ok(ApiResponse.onSuccess("마크다운 파일 저장 성공"));
+			fileSystemService.updateMarkdown(requestDTO);
+			return ResponseEntity.ok(ApiResponse.onSuccess("마크다운 파일 내용 업데이트 성공"));
 		} catch (Exception e) {
-			return ResponseEntity.status(500).body(ApiResponse.onFailure("MARKDOWN_SAVE_ERROR", e.getMessage(), null));
+			return ResponseEntity.status(500).body(ApiResponse.onFailure("MARKDOWN_UPDATE_ERROR", e.getMessage(), null));
 		}
 	}
 

--- a/src/main/java/Obsidian/demo/dto/MarkDownSaveRequestDTO.java
+++ b/src/main/java/Obsidian/demo/dto/MarkDownSaveRequestDTO.java
@@ -12,6 +12,5 @@ import lombok.NoArgsConstructor;
 public class MarkDownSaveRequestDTO {
 
 	private String filePath;
-	private String fileName;
 	private String content;
 }

--- a/src/main/java/Obsidian/demo/service/FileSystemService.java
+++ b/src/main/java/Obsidian/demo/service/FileSystemService.java
@@ -142,6 +142,10 @@ public class FileSystemService {
 		try {
 			Path filePath = Paths.get(requestDTO.getFilePath());
 
+			// 파일 이름 추출
+			String fileName = filePath.getFileName().toString();
+			log.info("업데이트할 파일 이름: {}", fileName);
+
 			// 파일 존재 여부 확인
 			if (!Files.exists(filePath)) {
 				throw new RuntimeException("파일이 존재하지 않습니다: " + filePath);

--- a/src/main/java/Obsidian/demo/service/FileSystemService.java
+++ b/src/main/java/Obsidian/demo/service/FileSystemService.java
@@ -137,35 +137,22 @@ public class FileSystemService {
 
 		fileSystemUtil.updateFileTree();
 	}
-	public void saveMarkdown(MarkDownSaveRequestDTO requestDTO) {
+
+	public void updateMarkdown(MarkDownSaveRequestDTO requestDTO) {
 		try {
-			// 기존 파일 경로
-			Path oldFilePath = Paths.get(requestDTO.getFilePath());
+			Path filePath = Paths.get(requestDTO.getFilePath());
 
-			// 새 파일 경로 (파일 이름 변경)
-			Path newFilePath = Paths.get(oldFilePath.getParent().toString(), requestDTO.getFileName());
-
-			// .md 확장자 추가 (이미 확장자가 없는 경우)
-			if (!newFilePath.toString().endsWith(".md")) {
-				newFilePath = Paths.get(newFilePath.toString() + ".md");
+			// 파일 존재 여부 확인
+			if (!Files.exists(filePath)) {
+				throw new RuntimeException("파일이 존재하지 않습니다: " + filePath);
 			}
 
-			// 디렉토리 생성 (필요한 경우)
-			if (!Files.exists(newFilePath.getParent())) {
-				Files.createDirectories(newFilePath.getParent());
-			}
+			// 파일 내용 업데이트
+			Files.write(filePath, requestDTO.getContent().getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
 
-			// 파일 이동 (파일 이름 변경)
-			if (!oldFilePath.equals(newFilePath)) {
-				Files.move(oldFilePath, newFilePath, StandardCopyOption.REPLACE_EXISTING);
-			}
-
-			// 파일 내용 저장 (덮어쓰기)
-			Files.write(newFilePath, requestDTO.getContent().getBytes(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-
-			log.info("Markdown 파일 저장 및 이름 변경 성공: {}", newFilePath);
+			log.info("Markdown 파일 내용 업데이트 성공: {}", filePath);
 		} catch (IOException e) {
-			log.error("Markdown 저장 중 오류 발생: {}", e.getMessage());
+			log.error("Markdown 내용 업데이트 중 오류 발생: {}", e.getMessage());
 			throw new GeneralException(ErrorStatus.MARKDOWN_SAVE_ERROR);
 		}
 	}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #30 

## 📌 개요

1.  Service
    - saveMarkdown 메서드를 updateMarkdown으로 변경하여 파일 내용 업데이트만 처리하도록 수정

2. Controller
    - /update 엔드포인트 추가: 파일 내용 업데이트 처리
    - @Operation 주석 수정

## 🔁 변경 사항

1. MarkDownSaveRequestDTO.java 
  - fileName 필드 삭제 ( 내용 변경의 경우는 filePath 내부에 포함된 fileName을 그대로 사용하기 때문에 필드 삭제했습니다)

## 📸 스크린샷 (선택)

1. 루트 파일 내용 변경
![image](https://github.com/user-attachments/assets/c9464e68-96b3-420f-b9e7-d2396cf78fea)

2. 폴더 하위 파일 내용 변경
![image](https://github.com/user-attachments/assets/22932ac9-e43a-4412-8b25-2df9ceda3294)



## 👀 기타 더 이야기해볼 점 (선택)

## 💬 리뷰 요구사항 (선택)

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.